### PR TITLE
Basic support to build Nora non-UI side as a qml plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,23 @@ nimble setup_android
 
 nimble android_run
 ```
+
+#### Building as a qml plugin
+```sh
+nimble setup
+nimble qml_plugin_build
+```
+The plugin must be available to the app by specifying import path. It can be
+done in multiple ways (https://doc.qt.io/qt-6/qtqml-syntax-imports.html#qml-import-path).
+From QML the plugin can be loaded by
+```qml
+import Nora
+```
+Currently, the plugin sets the context property `main` in the same way as it's
+done in the full Nora app.
+
+> [!NOTE]
+> Because of the current limitations of seaqt, the app using the plugin must
+> register the module by calling `qmlRegisterModule("Nora", 1, 0);` in order
+> to make the qml imports working. In the future this will be replaced by
+> registration directly in the plugin code.

--- a/build_plugin.nims
+++ b/build_plugin.nims
@@ -1,0 +1,25 @@
+mode = ScriptMode.Verbose
+
+import std.os
+
+# Project constants
+const
+  ModuleName = "Nora"
+  PluginSourceFile = "src/nora.nim"
+
+task qml_plugin_build, "Building nora lib as a qml plugin":
+  let
+    workspaceDir = getCurrentDir()
+    nimCmd = &"nim c --app:lib -d:moduleName=\"{ModuleName}\" " &
+      &"--outdir:\"{workspaceDir / \"build\" / ModuleName}\" " &
+      &"\"{workspaceDir / PluginSourceFile}\""
+
+  let result = gorgeEx(nimCmd)
+
+  if result.exitCode != 0:
+    echo "Command failed: ", nimCmd
+    echo "Output: ", result.output
+
+task qml_plugin_clean, "Clean plugin build":
+  let workspaceDir = getCurrentDir()
+  rmDir(workspaceDir / "build" / ModuleName)

--- a/nora.nimble
+++ b/nora.nimble
@@ -17,5 +17,5 @@ requires "nim >= 2.0.12",
 
 # Include task scripts
 include "setup_android.nims"
-# include "deploy_android.nims"
 include "deploy_android.nims"
+include "build_plugin.nims"

--- a/src/nora.nim
+++ b/src/nora.nim
@@ -4,15 +4,18 @@ import
   chronicles,
   json_rpc/[client, private/jrpc_sys],
   chronos,
-  ./[apicalls, threadchannel]
+  ./[apicalls, threadchannel, plugingen]
 
 import
   seaqt/[
     qapplication, qabstractlistmodel, qabstracttablemodel, qqmlapplicationengine,
     qqmlcontext, qurl, qobject, qvariant, qmetatype, qmetaproperty, qstringlistmodel,
+    qqmlextensionplugin
   ],
   seaqt/QtCore/[gen_qnamespace, qtcore_pkg],
   ./nimside
+
+const endpointUri = "http://localhost:8545"
 
 func gorgeOrFail(cmd: string): string {.compileTime.} =
   let (output, exitCode) = gorgeEx(cmd)
@@ -186,14 +189,11 @@ qobject:
         except CatchableError as exc:
           "Can't encode request: " & exc.msg
 
-proc initApp(uri: string) =
-  let
-    _ = QApplication.create()
-    main = MainModel(
-      urls: QStringListModel.create([uri]), url: uri, apiNames: apiList.mapIt(it.name)
-    )
-    engine = QQmlApplicationEngine.create()
-
+proc newMainModel(uri: string, apiNames: seq[string]): MainModel =
+  let main = MainModel()
+  main.urls = QStringListModel.create([uri])
+  main.url = uri
+  main.apiNames = apiList.mapIt(it.name)
   main.params = ParamsList.init(apiList[0])
   main.worker = WorkerObject()
   main.worker.setup()
@@ -213,6 +213,13 @@ proc initApp(uri: string) =
           break
 
   main.chan.open()
+  main
+
+proc initApp(uri: string) =
+  let
+    _ = QApplication.create()
+    main = newMainModel(uri, apiList.mapIt(it.name))
+    engine = QQmlApplicationEngine.create()
 
   var ct: Thread[ThreadArg]
   createThread(ct, chronosThread, (addr main.chan, addr main.worker[]))
@@ -221,7 +228,6 @@ proc initApp(uri: string) =
 
   engine.addImportPath("qrc:/")
   engine.load(QUrl.create("qrc:/ui/main.qml"))
-  # engine.load(QUrl.create("file://home/arnetheduck/status/nora/src/ui/main.qml"))
 
   discard QApplication.exec()
 
@@ -230,12 +236,33 @@ proc initApp(uri: string) =
 
   main.chan.close()
 
+type NoraPlugin = ref object of VirtualQQmlExtensionPlugin
+  main: MainModel
+  ct: Thread[ThreadArg]
+
+method registerTypes*(self: NoraPlugin, uri: cstring) =
+  echo "TODO: REGISTER TYPES FROM NIM THERE!"
+
+method initializeEngine*(self: NoraPlugin, engine: QQmlEngine, uri: cstring) =
+  self.main = newMainModel(endpointUri, apiList.mapIt(it.name))
+
+  try:
+    createThread(self.ct, chronosThread, (addr self.main.chan, addr self.main.worker[]))
+  except:
+    echo "createThread failed!"
+
+  engine.rootContext().setContextProperty("main", self.main[])
+
 when appType == "lib" or appType == "staticlib":
   proc NimMain() {.importc.}
   proc main(): cint {.exportc, dynlib, cdecl.} =
     NimMain() # Initialize Nim runtime first
-    initApp("http://localhost:8545")
+    initApp(endpointUri)
     return 0
 
+when appType == "lib" and defined(moduleName):
+  const moduleName {.strdefine.}: string = "Nora"
+  generatePlugin(T = NoraPlugin, moduleName, uri = "Nora")
+
 when isMainModule and appType != "lib" and appType != "staticlib":
-  initApp("http://localhost:8545")
+  initApp(endpointUri)

--- a/src/plugingen.nim
+++ b/src/plugingen.nim
@@ -1,0 +1,109 @@
+import std/[macros, compilesettings]
+
+const
+  QtQmlCFlags =
+    gorge("pkg-config --cflags Qt6Qml") &
+    (when defined(gcc) or defined(llvm): " -fPIC" else: "")
+
+macro createDirAtCompileTime(dir: string): untyped =
+  result = quote do:
+    static:
+      discard staticExec("mkdir -p " & `dir`)
+
+macro writeFileAtCompileTime(filename: string, content: string): untyped =
+  result = quote do:
+    static:
+      writeFile(`filename`, `content`)
+
+
+func encodeCBORPluginMetaCxxArray(
+  iid, className, uri: static[string]
+): string =
+  ## Based on https://codereview.qt-project.org/c/qt/qtbase/+/370750/5/src/tools/moc/generator.cpp#1571
+  ## Basic plugin metadata encoder. Returns the C++ unsigned char array representation
+  ## of the CBOR-encoded plugin metadata.
+  const indent = "    "
+  proc cborStringHeader(len: int): string =
+    if len <= 23:
+      result = "0x" & (0x60 + len).toHex(2) & ", "
+    else:
+      result = "0x78, 0x" & len.toHex(2) & ", "
+
+  proc appendAscii(s: string, res: var string) =
+    for i, c in s:
+      res.add("'" & c & "', ")
+      if (i + 1) mod 8 == 0 and i < s.high:
+        res.add("\n" & indent)
+    res.add("\n")
+
+  proc appendComment(s: string, res: var string) =
+    res.add(indent & "// \"" & s & "\"\n")
+
+  var res = indent & "0xBF," & "\n"
+  # IID
+  appendComment("IID", res)
+  res.add(indent & "0x02, ") # QtPluginMetaDataKeys::IID = 0x02
+  res.add(cborStringHeader(iid.len) & "\n" & indent)
+  appendAscii(iid, res)
+
+  # className
+  appendComment("className", res)
+  res.add(indent & "0x03, ") # QtPluginMetaDataKeys::ClassName = 0x03
+  res.add(cborStringHeader(className.len) & "\n" & indent)
+  appendAscii(className, res)
+
+  # "uri"
+  appendComment("uri", res)
+  res.add(indent & "0x63, 'u', 'r', 'i',\n" & indent & "0x81,\n" & indent)
+  res.add(cborStringHeader(uri.len) & "\n" & indent)
+  appendAscii(uri, res)
+  res.add("\n" & indent & "0xff,\n")
+  res
+
+func generateCppMetadataHandlerCode(iid, className, uri: static[string]): string =
+  """
+#include <QtCore/qplugin.h>
+
+static constexpr unsigned char qt_pluginMetaData[] = {
+""" & encodeCBORPluginMetaCxxArray(iid, className, uri) & """
+
+};
+
+extern "C" Q_DECL_EXPORT QT_PREPEND_NAMESPACE(QPluginMetaData) qt_plugin_query_metadata_v2()
+{
+    static constexpr QT_PLUGIN_METADATAV2_SECTION QPluginMetaDataV2<qt_pluginMetaData> md{};
+    return md;
+}
+
+"""
+
+func generateQmldirContent(moduleName, libName: static[string]): string =
+  "module " & moduleName & "\n" &
+  "plugin " & libName
+
+
+macro generatePlugin*(T: typed, moduleName, uri: string): untyped =
+  result = quote do:
+    const pluginDir = querySetting(SingleValueSetting.outDir)
+    const nimcacheDir = querySetting(SingleValueSetting.nimcacheDir)
+    const pluginRegistrationCppFile = nimcacheDir / "pluginRegistration.cpp"
+
+    const iid = "org.qt-project.Qt.QQmlExtensionInterface/1.0"
+    const cppContent = generateCppMetadataHandlerCode(iid, $(typeof(`T`)), `uri`)
+
+    writeFileAtCompileTime(pluginRegistrationCppFile, cppContent)
+    {.compile(pluginRegistrationCppFile, QtQmlCFlags)}
+
+    createDirAtCompileTime(pluginDir)
+
+    const projectName = querySetting(SingleValueSetting.projectName)
+    const qmldirPath = pluginDir / "qmldir"
+    const qmldirContent = generateQmldirContent(`moduleName`, projectName)
+
+    writeFileAtCompileTime(qmldirPath, qmldirContent)
+
+    let pluginSingleton = `T`()
+    QQmlExtensionPlugin.create(pluginSingleton)
+
+    proc qt_plugin_instance(): pointer {.exportc, dynlib, cdecl.} =
+      return pluginSingleton.h


### PR DESCRIPTION
Adds ability to compile the app (backend part) as a QML plugin. Therefore it can be consumed by any QML app by just importing the plugin.

The video presents Nora backend used within `status-desktop`'s Storybook (qt/qml/cpp):

[Screencast from 30.05.2025 11:53:33.webm](https://github.com/user-attachments/assets/eb0289e0-56e6-4c5c-ae91-0fd704b592b6)
